### PR TITLE
refactor(mm, trap): get the user and kernel to share the page table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.ignoreCMakeListsMissing": true
+}

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ KERNEL_ENTRY_PA := 0x80200000
 # Binutils
 OBJDUMP := rust-objdump --arch-name=riscv64
 OBJCOPY := rust-objcopy --binary-architecture=riscv64
-GDB ?= riscv64-unknown-elf-gdb
+GDB ?= riscv64-linux-gnu-gdb
 
 # Disassembly
 DISASM ?= -x

--- a/os/src/arch/mod.rs
+++ b/os/src/arch/mod.rs
@@ -1,0 +1,1 @@
+pub mod riscv64;

--- a/os/src/arch/riscv64/entry.rs
+++ b/os/src/arch/riscv64/entry.rs
@@ -1,0 +1,55 @@
+const PTES_PER_PAGE: usize = 512;
+const KERNEL_STACK_SIZE: usize = 4096 * 16;
+const VIRT_RAM_OFFSET: usize = 0xffff_ffc0_0000_0000;
+
+#[link_section = ".bss.stack"]
+static mut BOOT_STACK: [u8; KERNEL_STACK_SIZE] = [0u8; KERNEL_STACK_SIZE];
+
+#[repr(C, align(4096))]
+pub struct BootPageTable([u64; PTES_PER_PAGE]);
+
+pub static mut BOOT_PAGE_TABLE: BootPageTable = {
+    let mut arr: [u64; PTES_PER_PAGE] = [0; PTES_PER_PAGE];
+    arr[2] = (0x80000 << 10) | 0xcf;
+    arr[256] = (0x00000 << 10) | 0xcf;
+    arr[258] = (0x80000 << 10) | 0xcf;
+    BootPageTable(arr)
+};
+
+#[naked]
+#[no_mangle]
+#[link_section = ".text.entry"]
+unsafe extern "C" fn _start() -> ! {
+    core::arch::naked_asm!(
+        // 1. set boot stack
+        // sp = boot_stack + (hartid + 1) * 64KB
+        "
+            addi    t0, x0, 1
+            slli    t0, t0, 16              // t0 = (hart_id + 1) * 64KB
+            la      sp, {boot_stack}
+            add     sp, sp, t0              // set boot stack
+        ",
+        // 2. enable sv39 page table
+        // satp = (8 << 60) | PPN(page_table)
+        "
+            la      t0, {page_table}
+            srli    t0, t0, 12
+            li      t1, 8 << 60
+            or      t0, t0, t1
+            csrw    satp, t0
+            sfence.vma
+        ",
+        // 3. jump to rust_main
+        // add virtual address offset to sp and pc
+        "
+            li      t2, {virt_ram_offset}
+            or      sp, sp, t2
+            la      a2, rust_main
+            or      a2, a2, t2
+            jalr    a2                      // call rust_main
+        ",
+        boot_stack = sym BOOT_STACK,
+        page_table = sym BOOT_PAGE_TABLE,
+        virt_ram_offset = const VIRT_RAM_OFFSET,
+    )
+}

--- a/os/src/arch/riscv64/mod.rs
+++ b/os/src/arch/riscv64/mod.rs
@@ -1,0 +1,8 @@
+pub unsafe fn sfence_vma_vaddr(va: usize) {
+    core::arch::asm!("sfence.vma {}, x0", in(reg) va, options(nostack));
+}
+pub unsafe fn sfence_vma_all() {
+    core::arch::asm!("sfence.vma");
+}
+
+pub mod entry;

--- a/os/src/config.rs
+++ b/os/src/config.rs
@@ -2,14 +2,18 @@
 #[allow(unused)]
 
 pub const USER_STACK_SIZE: usize = 4096 * 2;
-pub const KERNEL_STACK_SIZE: usize = 4096 * 10;
+pub const KERNEL_STACK_SIZE: usize = 4096 * 16;
 pub const KERNEL_HEAP_SIZE: usize = 0x20_0000;
+pub const KERNEL_ADDR_OFFSET: usize = 0xffff_ffc0_0000_0000;
 
 pub const PAGE_SIZE: usize = 0x1000;
 pub const PAGE_SIZE_BITS: usize = 0xc;
 
-pub const TRAMPOLINE: usize = usize::MAX - PAGE_SIZE + 1;
-pub const TRAP_CONTEXT: usize = TRAMPOLINE - PAGE_SIZE;
+pub const TRAP_CONTEXT: usize = USER_MEMORY_SPACE.1 - PAGE_SIZE + 1;
+
+#[allow(unused)]
+pub const KERNEL_MEMORY_SPACE: (usize, usize) = (0xffff_ffc0_0000_0000, 0xffff_ffff_ffff_ffff);
+pub const USER_MEMORY_SPACE: (usize, usize) = (0x0, 0x3f_ffff_ffff);
 
 pub use crate::board::{CLOCK_FREQ, MEMORY_END, MMIO};
 

--- a/os/src/drivers/block/virtio_blk.rs
+++ b/os/src/drivers/block/virtio_blk.rs
@@ -1,10 +1,9 @@
 //! VirtIO block device driver
 
 use crate::devices::BlockDevice;
-use crate::config::BLOCK_SIZE;
+use crate::config::{BLOCK_SIZE, KERNEL_ADDR_OFFSET};
 use crate::mm::{
-    frame_alloc, frame_dealloc, kernel_token, FrameTracker, PageTable, PhysAddr, PhysPageNum,
-    StepByOne, VirtAddr, KERNEL_SPACE
+    frame_alloc, frame_dealloc, FrameTracker, PageTable, PhysAddr, PhysPageNum, VirtAddr, VmSpace, KERNEL_SPACE
 };
 use crate::sync::UPSafeCell;
 use alloc::vec::Vec;
@@ -22,7 +21,7 @@ use log::*;
 use crate::logging;
 
 #[allow(unused)]
-const VIRTIO0: usize = 0x10001000;
+const VIRTIO0: usize = 0x10001000 + KERNEL_ADDR_OFFSET;
 
 pub struct VirtIOBlock(UPSafeCell<VirtIOBlk<VirtioHal, MmioTransport>>);
 
@@ -93,7 +92,7 @@ unsafe impl virtio_drivers::Hal for VirtioHal {
         let mut ppn_base: PhysPageNum = pa.into();
         for _ in 0..pages {
             frame_dealloc(ppn_base);
-            ppn_base.step();
+            ppn_base += 1;
         }
         0
     }

--- a/os/src/fs/disk.rs
+++ b/os/src/fs/disk.rs
@@ -24,7 +24,6 @@ pub struct Disk {
 impl Disk {
     /// Create a new disk.
     pub fn new(dev: Arc<dyn BlockDevice>) -> Self {
-        
         Self {
             block_id: 0,
             offset: 0,

--- a/os/src/fs/ext4fs.rs
+++ b/os/src/fs/ext4fs.rs
@@ -143,7 +143,6 @@ impl Inode {
     }
 
     /// list all files' name in the directory
-    #[allow(unused)]
     pub fn ls(&self) -> Vec<String> {
         let file = self.0.borrow_mut();
 

--- a/os/src/linker-qemu.ld
+++ b/os/src/linker-qemu.ld
@@ -1,6 +1,6 @@
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-BASE_ADDRESS = 0x80200000;
+BASE_ADDRESS = 0xFFFFFFC080200000;
 
 SECTIONS
 {
@@ -10,10 +10,6 @@ SECTIONS
     stext = .;
     .text : {
         *(.text.entry)
-        . = ALIGN(4K);
-        strampoline = .;
-        *(.text.trampoline);
-        . = ALIGN(4K);
         *(.text .text.*)
     }
 

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -24,6 +24,9 @@
 #![no_std]
 #![no_main]
 #![feature(alloc_error_handler)]
+#![feature(step_trait)]
+#![feature(new_range_api)]
+#![feature(naked_functions)]
 
 extern crate alloc;
 
@@ -50,10 +53,11 @@ pub mod syscall;
 pub mod task;
 pub mod timer;
 pub mod trap;
+mod arch;
 
 use core::arch::global_asm;
 
-global_asm!(include_str!("entry.asm"));
+// global_asm!(include_str!("entry.asm"));
 /// clear BSS segment
 fn clear_bss() {
     extern "C" {

--- a/os/src/mm/frame_allocator.rs
+++ b/os/src/mm/frame_allocator.rs
@@ -1,20 +1,21 @@
 //! Implementation of [`FrameAllocator`] which
 //! controls all the frames in the operating system.
+
 use super::{PhysAddr, PhysPageNum};
-use crate::config::MEMORY_END;
+use crate::config::{KERNEL_ADDR_OFFSET, MEMORY_END};
 use crate::sync::UPSafeCell;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Formatter};
 use lazy_static::*;
 
 /// manage a frame which has the same lifecycle as the tracker
+#[allow(missing_docs)]
 pub struct FrameTracker {
-    ///
     pub ppn: PhysPageNum,
 }
 
+#[allow(missing_docs)]
 impl FrameTracker {
-    ///Create an empty `FrameTracker`
     pub fn new(ppn: PhysPageNum) -> Self {
         // page cleaning
         let bytes_array = ppn.get_bytes_array();
@@ -42,6 +43,7 @@ trait FrameAllocator {
     fn alloc(&mut self) -> Option<PhysPageNum>;
     fn dealloc(&mut self, ppn: PhysPageNum);
 }
+
 /// an implementation for frame allocator
 pub struct StackFrameAllocator {
     current: usize,
@@ -53,7 +55,6 @@ impl StackFrameAllocator {
     pub fn init(&mut self, l: PhysPageNum, r: PhysPageNum) {
         self.current = l.0;
         self.end = r.0;
-        println!("last {} Physical Frames.", self.end - self.current);
     }
 }
 impl FrameAllocator for StackFrameAllocator {
@@ -92,16 +93,18 @@ lazy_static! {
     pub static ref FRAME_ALLOCATOR: UPSafeCell<FrameAllocatorImpl> =
         unsafe { UPSafeCell::new(FrameAllocatorImpl::new()) };
 }
+
 /// initiate the frame allocator using `ekernel` and `MEMORY_END`
 pub fn init_frame_allocator() {
     extern "C" {
         fn ekernel();
     }
     FRAME_ALLOCATOR.exclusive_access().init(
-        PhysAddr::from(ekernel as usize).ceil(),
+        PhysAddr::from(ekernel as usize - KERNEL_ADDR_OFFSET).ceil(),
         PhysAddr::from(MEMORY_END).floor(),
     );
 }
+
 /// allocate a frame
 pub fn frame_alloc() -> Option<FrameTracker> {
     FRAME_ALLOCATOR
@@ -109,6 +112,7 @@ pub fn frame_alloc() -> Option<FrameTracker> {
         .alloc()
         .map(FrameTracker::new)
 }
+
 /// deallocate a frame
 pub fn frame_dealloc(ppn: PhysPageNum) {
     FRAME_ALLOCATOR.exclusive_access().dealloc(ppn);

--- a/os/src/mm/heap_allocator.rs
+++ b/os/src/mm/heap_allocator.rs
@@ -2,7 +2,6 @@
 
 use crate::config::KERNEL_HEAP_SIZE;
 use buddy_system_allocator::LockedHeap;
-
 #[global_allocator]
 /// heap allocator instance
 static HEAP_ALLOCATOR: LockedHeap = LockedHeap::empty();
@@ -17,9 +16,9 @@ pub fn handle_alloc_error(layout: core::alloc::Layout) -> ! {
 static mut HEAP_SPACE: [u8; KERNEL_HEAP_SIZE] = [0; KERNEL_HEAP_SIZE];
 
 /// initiate heap allocator
-#[allow(static_mut_refs)]
 pub fn init_heap() {
     unsafe {
+        #[allow(static_mut_refs)]
         HEAP_ALLOCATOR
             .lock()
             .init(HEAP_SPACE.as_ptr() as usize, KERNEL_HEAP_SIZE);

--- a/os/src/mm/memory_set.rs
+++ b/os/src/mm/memory_set.rs
@@ -382,28 +382,3 @@ bitflags! {
         const U = 1 << 4;
     }
 }
-
-#[allow(unused)]
-///Check PageTable running correctly
-pub fn remap_test() {
-    let mut kernel_space = KERNEL_SPACE.exclusive_access();
-    let mid_text: VirtAddr = ((stext as usize + etext as usize) / 2).into();
-    let mid_rodata: VirtAddr = ((srodata as usize + erodata as usize) / 2).into();
-    let mid_data: VirtAddr = ((sdata as usize + edata as usize) / 2).into();
-    assert!(!kernel_space
-        .page_table
-        .translate(mid_text.floor())
-        .unwrap()
-        .writable(),);
-    assert!(!kernel_space
-        .page_table
-        .translate(mid_rodata.floor())
-        .unwrap()
-        .writable(),);
-    assert!(!kernel_space
-        .page_table
-        .translate(mid_data.floor())
-        .unwrap()
-        .executable(),);
-    println!("remap_test passed!");
-}

--- a/os/src/mm/mod.rs
+++ b/os/src/mm/mod.rs
@@ -5,25 +5,25 @@
 //! map area and memory set, is implemented here.
 //!
 //! Every task or process has a memory_set to control its virtual memory.
+
 mod address;
 mod frame_allocator;
 mod heap_allocator;
-mod memory_set;
 mod page_table;
+mod vm_area;
+mod vm_space;
 
-use address::VPNRange;
-pub use address::{PhysAddr, PhysPageNum, StepByOne, VirtAddr, VirtPageNum};
+pub use address::{PhysAddr, PhysPageNum, VirtAddr, VirtPageNum};
 pub use frame_allocator::{frame_alloc, frame_dealloc, FrameTracker};
-pub use memory_set::remap_test;
-pub use memory_set::{kernel_token, MapPermission, MemorySet, KERNEL_SPACE};
-use page_table::PTEFlags;
-pub use page_table::{
-    translated_byte_buffer, translated_ref, translated_refmut, translated_str, PageTable,
-    PageTableEntry, UserBuffer, UserBufferIterator,
-};
+pub use page_table::{translated_byte_buffer, PageTableEntry, translated_str, translated_ref, translated_refmut, UserBuffer};
+pub use page_table::{PTEFlags, PageTable};
+#[allow(unused)]
+pub use vm_area::{UserVmArea, KernelVmArea, VmArea, VmAreaFrameExt, MapPerm, KernelVmAreaType, UserVmAreaType};
+pub use vm_space::{VmSpace, KERNEL_SPACE, UserVmSpace, remap_test};
+
 /// initiate heap allocator, frame allocator and kernel space
 pub fn init() {
     heap_allocator::init_heap();
     frame_allocator::init_frame_allocator();
-    KERNEL_SPACE.exclusive_access().activate();
+    KERNEL_SPACE.exclusive_access().enable();
 }

--- a/os/src/mm/page_table.rs
+++ b/os/src/mm/page_table.rs
@@ -1,76 +1,92 @@
 //! Implementation of [`PageTableEntry`] and [`PageTable`].
-use super::{frame_alloc, FrameTracker, PhysAddr, PhysPageNum, StepByOne, VirtAddr, VirtPageNum};
+
+use super::{frame_alloc, FrameTracker, PhysAddr, PhysPageNum, VirtAddr, VirtPageNum};
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use bitflags::*;
-
 bitflags! {
+    /// page table entry flags
     pub struct PTEFlags: u8 {
+        #[allow(missing_docs)]
         const V = 1 << 0;
+        #[allow(missing_docs)]
         const R = 1 << 1;
+        #[allow(missing_docs)]
         const W = 1 << 2;
+        #[allow(missing_docs)]
         const X = 1 << 3;
+        #[allow(missing_docs)]
         const U = 1 << 4;
+        #[allow(missing_docs)]
         const G = 1 << 5;
+        #[allow(missing_docs)]
         const A = 1 << 6;
+        #[allow(missing_docs)]
         const D = 1 << 7;
     }
 }
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+#[allow(missing_docs)]
 /// page table entry structure
 pub struct PageTableEntry {
-    ///PTE
     pub bits: usize,
 }
 
+#[allow(missing_docs)]
 impl PageTableEntry {
-    ///Create a PTE from ppn
     pub fn new(ppn: PhysPageNum, flags: PTEFlags) -> Self {
         PageTableEntry {
             bits: ppn.0 << 10 | flags.bits as usize,
         }
     }
-    ///Return an empty PTE
     pub fn empty() -> Self {
         PageTableEntry { bits: 0 }
     }
-    ///Return 44bit ppn
     pub fn ppn(&self) -> PhysPageNum {
         (self.bits >> 10 & ((1usize << 44) - 1)).into()
     }
-    ///Return 10bit flag
     pub fn flags(&self) -> PTEFlags {
         PTEFlags::from_bits(self.bits as u8).unwrap()
     }
-    ///Check PTE valid
     pub fn is_valid(&self) -> bool {
         (self.flags() & PTEFlags::V) != PTEFlags::empty()
     }
-    ///Check PTE readable
     pub fn readable(&self) -> bool {
         (self.flags() & PTEFlags::R) != PTEFlags::empty()
     }
-    ///Check PTE writable
     pub fn writable(&self) -> bool {
         (self.flags() & PTEFlags::W) != PTEFlags::empty()
     }
-    ///Check PTE executable
     pub fn executable(&self) -> bool {
         (self.flags() & PTEFlags::X) != PTEFlags::empty()
     }
+    // pte.is_leaf() == true, meaning this PTE points to the physical page, not to the next level of PTE.
+    pub fn is_leaf(&self) -> bool {
+        (self.flags() & PTEFlags::V) != PTEFlags::empty() && 
+        (
+            (self.flags() & PTEFlags::R) != PTEFlags::empty() ||
+            (self.flags() & PTEFlags::W) != PTEFlags::empty() ||
+            (self.flags() & PTEFlags::X) != PTEFlags::empty()
+        )
+    }
+    pub fn set_flags(&mut self, flags: PTEFlags) {
+        self.bits = ((self.bits >> 10) << 10) | flags.bits() as usize;
+    }
 }
-///Record root ppn and has the same lifetime as 1 and 2 level `PageTableEntry`
+
+/// page table structure
+#[allow(missing_docs)]
 pub struct PageTable {
-    root_ppn: PhysPageNum,
+    pub root_ppn: PhysPageNum,
     frames: Vec<FrameTracker>,
 }
 
 /// Assume that it won't oom when creating/mapping.
+#[allow(missing_docs)]
 impl PageTable {
-    /// Create an empty `PageTable`
     pub fn new() -> Self {
         let frame = frame_alloc().unwrap();
         PageTable {
@@ -85,7 +101,6 @@ impl PageTable {
             frames: Vec::new(),
         }
     }
-    /// Find phsical address by virtual address, create a frame if not exist
     fn find_pte_create(&mut self, vpn: VirtPageNum) -> Option<&mut PageTableEntry> {
         let idxs = vpn.indexes();
         let mut ppn = self.root_ppn;
@@ -105,8 +120,7 @@ impl PageTable {
         }
         result
     }
-    /// Find phsical address by virtual address
-    fn find_pte(&self, vpn: VirtPageNum) -> Option<&mut PageTableEntry> {
+    pub fn find_pte(&self, vpn: VirtPageNum) -> Option<&mut PageTableEntry> {
         let idxs = vpn.indexes();
         let mut ppn = self.root_ppn;
         let mut result: Option<&mut PageTableEntry> = None;
@@ -124,24 +138,38 @@ impl PageTable {
         result
     }
     #[allow(unused)]
-    /// Create a mapping form `vpn` to `ppn`
+    pub fn find_leaf_pte(&self, vpn: VirtPageNum) -> Option<&mut PageTableEntry> {
+        let idxs = vpn.indexes();
+        let mut ppn = self.root_ppn;
+        let mut result: Option<&mut PageTableEntry> = None;
+        for (i, idx) in idxs.iter().enumerate() {
+            let pte = &mut ppn.get_pte_array()[*idx];
+            if pte.is_leaf() || i == 2 {
+                result = Some(pte);
+                break;
+            }
+            if !pte.is_valid() {
+                return None;
+            }
+            ppn = pte.ppn();
+        }
+        result
+    }
+    #[allow(unused)]
     pub fn map(&mut self, vpn: VirtPageNum, ppn: PhysPageNum, flags: PTEFlags) {
         let pte = self.find_pte_create(vpn).unwrap();
         assert!(!pte.is_valid(), "vpn {:?} is mapped before mapping", vpn);
         *pte = PageTableEntry::new(ppn, flags | PTEFlags::V);
     }
     #[allow(unused)]
-    /// Delete a mapping form `vpn`
     pub fn unmap(&mut self, vpn: VirtPageNum) {
         let pte = self.find_pte(vpn).unwrap();
         assert!(pte.is_valid(), "vpn {:?} is invalid before unmapping", vpn);
         *pte = PageTableEntry::empty();
     }
-    /// Translate `VirtPageNum` to `PageTableEntry`
     pub fn translate(&self, vpn: VirtPageNum) -> Option<PageTableEntry> {
         self.find_pte(vpn).map(|pte| *pte)
     }
-    /// Translate `VirtAddr` to `PhysAddr`
     pub fn translate_va(&self, va: VirtAddr) -> Option<PhysAddr> {
         self.find_pte(va.clone().floor()).map(|pte| {
             let aligned_pa: PhysAddr = pte.ppn().into();
@@ -150,12 +178,19 @@ impl PageTable {
             (aligned_pa_usize + offset).into()
         })
     }
-    /// Get root ppn
     pub fn token(&self) -> usize {
         8usize << 60 | self.root_ppn.0
     }
+    pub unsafe fn enable(&self) {
+        // for x in self.root_ppn.get_pte_array() {
+        //     info!("{:#x}", x.ppn().0 << 12);
+        // }
+        riscv::register::satp::write(self.token());
+        crate::arch::riscv64::sfence_vma_all();
+    }
 }
-/// Translate a pointer to a mutable u8 Vec through page table
+
+/// translate a pointer to a mutable u8 Vec through page table
 pub fn translated_byte_buffer(token: usize, ptr: *const u8, len: usize) -> Vec<&'static mut [u8]> {
     let page_table = PageTable::from_token(token);
     let mut start = ptr as usize;
@@ -165,7 +200,7 @@ pub fn translated_byte_buffer(token: usize, ptr: *const u8, len: usize) -> Vec<&
         let start_va = VirtAddr::from(start);
         let mut vpn = start_va.floor();
         let ppn = page_table.translate(vpn).unwrap().ppn();
-        vpn.step();
+        vpn += 1;
         let mut end_va: VirtAddr = vpn.into();
         end_va = end_va.min(VirtAddr::from(end));
         if end_va.page_offset() == 0 {
@@ -197,6 +232,7 @@ pub fn translated_str(token: usize, ptr: *const u8) -> String {
     string
 }
 
+
 #[allow(unused)]
 ///Translate a generic through page table and return a reference
 pub fn translated_ref<T>(token: usize, ptr: *const T) -> &'static T {
@@ -215,6 +251,7 @@ pub fn translated_refmut<T>(token: usize, ptr: *mut T) -> &'static mut T {
         .unwrap()
         .get_mut()
 }
+
 ///Array of u8 slice that user communicate with os
 pub struct UserBuffer {
     ///U8 vec

--- a/os/src/mm/vm_area.rs
+++ b/os/src/mm/vm_area.rs
@@ -1,0 +1,411 @@
+use core::ops::Range;
+
+use alloc::collections::btree_map::{BTreeMap, Keys};
+
+use crate::{arch::riscv64::sfence_vma_vaddr, config::{KERNEL_ADDR_OFFSET, PAGE_SIZE}};
+
+use super::{frame_alloc, page_table::{PTEFlags, PageTable}, FrameTracker, PhysAddr, PhysPageNum, VirtAddr, VirtPageNum};
+use bitflags::bitflags;
+
+bitflags! {
+    /// map permission corresponding to that in pte: `R W X U`
+    pub struct MapPerm: u8 {
+        #[allow(missing_docs)]
+        const R = 1 << 1;
+        #[allow(missing_docs)]
+        const W = 1 << 2;
+        #[allow(missing_docs)]
+        const X = 1 << 3;
+        #[allow(missing_docs)]
+        const U = 1 << 4;
+
+        #[allow(missing_docs)]
+        const RW = Self::R.bits() | Self::W.bits();
+        #[allow(missing_docs)]
+        const RX = Self::R.bits() | Self::X.bits();
+        #[allow(missing_docs)]
+        const WX = Self::W.bits() | Self::X.bits();
+        #[allow(missing_docs)]
+        const RWX = Self::R.bits() | Self::W.bits() | Self::X.bits();
+
+        #[allow(missing_docs)]
+        const UW = Self::U.bits() | Self::W.bits();
+        #[allow(missing_docs)]
+        const URW = Self::U.bits() | Self::RW.bits();
+        #[allow(missing_docs)]
+        const URX = Self::U.bits() | Self::RX.bits();
+        #[allow(missing_docs)]
+        const UWX = Self::U.bits() | Self::WX.bits();
+        #[allow(missing_docs)]
+        const URWX = Self::U.bits() | Self::RWX.bits();
+    }
+}
+
+impl From<MapPerm> for PTEFlags {
+    fn from(value: MapPerm) -> Self {
+        Self::from_bits_truncate(value.bits)
+    }
+}
+
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserVmAreaType {
+    Elf
+}
+
+#[allow(missing_docs)]
+pub trait VmArea
+{
+    fn range_va(&self) -> &Range<VirtAddr>;
+
+    fn range_va_mut(&mut self) -> &mut Range<VirtAddr>;
+
+    fn start_va(&self) -> VirtAddr {
+        self.range_va().start
+    }
+
+    fn end_va(&self) -> VirtAddr {
+        self.range_va().end
+    }
+
+    fn start_vpn(&self) -> VirtPageNum {
+        self.start_va().floor()
+    }
+
+    fn end_vpn(&self) -> VirtPageNum {
+        self.end_va().ceil()
+    }
+
+    fn range_vpn(&self) -> Range<VirtPageNum> {
+        self.start_vpn()..self.end_vpn()
+    }
+
+    fn set_range_va(&mut self, range_va: Range<VirtAddr>) {
+        *self.range_va_mut() = range_va
+    }
+
+    fn flush(&mut self) {
+        let range_vpn = self.range_vpn();
+        for vpn in range_vpn {
+            unsafe { sfence_vma_vaddr(vpn.into()) };
+        }
+    }
+
+    fn perm(&self) -> &MapPerm;
+
+    fn perm_mut(&mut self) -> &mut MapPerm;
+
+    fn set_perm(&mut self, perm: MapPerm) {
+        *self.perm_mut() = perm;
+    }
+
+    fn set_perm_flush(&mut self, perm: MapPerm) {
+        *self.perm_mut() = perm;
+        self.flush();
+    }
+
+    fn map_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>);
+
+    fn unmap_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>);
+
+    fn map(&mut self, page_table: &mut PageTable) {
+        self.map_range(page_table, self.range_vpn());
+    }
+
+    fn unmap(&mut self, page_table: &mut PageTable) {
+        self.unmap_range(page_table, self.range_vpn());
+    }
+
+    fn shrink_to(&mut self, page_table: &mut PageTable, new_end: VirtPageNum) {
+        self.unmap_range(page_table, new_end..self.end_vpn());
+        *self.range_va_mut() = self.start_vpn().into()..new_end.into();
+    }
+
+    fn append_to(&mut self, page_table: &mut PageTable, new_end: VirtPageNum) {
+        self.map_range(page_table, self.end_vpn()..new_end);
+        *self.range_va_mut() = self.start_vpn().into()..new_end.into();
+    }
+
+    fn copy_data(&mut self, page_table: &PageTable, data: &[u8]) {
+        let mut start: usize = 0;
+        let len = data.len();
+        for vpn in self.range_vpn() {
+            let src = &data[start..len.min(start + PAGE_SIZE)];
+            let dst = &mut page_table
+                .translate(vpn)
+                .unwrap()
+                .ppn()
+                .get_bytes_array()[..src.len()];
+            dst.copy_from_slice(src);
+            start += PAGE_SIZE;
+            if start >= len {
+                break;
+            }
+        }
+    }
+}
+
+
+#[allow(missing_docs)]
+pub trait VmAreaFrameExt: VmArea {
+    type FrameIter<'a>: Iterator<Item = &'a VirtPageNum> where Self: 'a;
+
+    fn allocated_frames_iter<'a>(&'a self) -> Self::FrameIter<'a>;
+
+    fn add_allocated_frame(&mut self, vpn: VirtPageNum, frame: FrameTracker);
+
+    fn remove_allocated_frame(&mut self, vpn: VirtPageNum);
+
+    fn map_range_and_alloc_frames(&mut self, page_table: &mut PageTable, range: Range<VirtPageNum>) {
+        range
+        .for_each(|vpn| {
+            let frame = frame_alloc().unwrap();
+            page_table.map(vpn, frame.ppn, (*self.perm()).into());
+            self.add_allocated_frame(vpn, frame);
+        });
+    }
+
+    fn unmap_range_and_dealloc_frames(&mut self, page_table: &mut PageTable, range: Range<VirtPageNum>) {
+        range
+        .for_each(|vpn| {
+            page_table.unmap(vpn);
+            self.remove_allocated_frame(vpn);
+        });
+    }
+
+    fn map_and_alloc_frames(&mut self, page_table: &mut PageTable) {
+        self.map_range_and_alloc_frames(page_table, self.range_vpn());
+    }
+
+    fn unmap_and_dealloc_frames(&mut self, page_table: &mut PageTable) {
+        self.unmap_range_and_dealloc_frames(page_table, self.range_vpn());
+    }
+
+    fn set_perm_and_flush_allocated_frames(&mut self, page_table: &mut PageTable, perm: MapPerm) {
+        self.set_perm(perm);
+        let pte_flags = perm.into();
+        // NOTE: should flush pages that already been allocated, page fault handler will
+        // handle the permission of those unallocated pages
+        for &vpn in self.allocated_frames_iter() {
+            let pte = page_table.find_leaf_pte(vpn).unwrap();
+            log::trace!(
+                "[origin pte:{:?}, new_flag:{:?}]",
+                pte.flags(),
+                pte.flags().union(pte_flags)
+            );
+            pte.set_flags(pte.flags().union(pte_flags));
+            unsafe { sfence_vma_vaddr(vpn.into()) };
+        }
+    }
+}
+
+
+/// User's Virtual Memory Area
+#[allow(missing_docs)]
+pub struct UserVmArea {
+    range_va: Range<VirtAddr>,
+    pub pages: BTreeMap<VirtPageNum, FrameTracker>,
+    pub map_perm: MapPerm,
+    pub vma_type: UserVmAreaType,
+}
+
+#[allow(missing_docs)]
+impl UserVmArea {
+    pub fn new(range_va: Range<VirtAddr>, map_perm: MapPerm, vma_type: UserVmAreaType) -> Self {
+        let range_va = range_va.start.floor().into()..range_va.end.ceil().into();
+        Self {
+            range_va,
+            pages: BTreeMap::new(),
+            map_perm,
+            vma_type
+        }
+    }
+}
+
+impl Clone for UserVmArea {
+    fn clone(&self) -> Self {
+        Self { 
+            range_va: self.range_va.clone(), 
+            pages: BTreeMap::new(), 
+            map_perm: self.map_perm.clone(), 
+            vma_type: self.vma_type.clone() 
+        }
+    }
+}
+
+impl VmArea for UserVmArea {
+    fn range_va(&self) -> &Range<VirtAddr> {
+        &self.range_va
+    }
+
+    fn range_va_mut(&mut self) -> &mut Range<VirtAddr> {
+        &mut self.range_va
+    }
+
+    fn perm(&self) -> &MapPerm {
+        &self.map_perm
+    }
+
+    fn perm_mut(&mut self) -> &mut MapPerm {
+        &mut self.map_perm
+    }
+    
+    fn map_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>) {
+        self.map_range_and_alloc_frames(page_table, range_vpn);
+    }
+    
+    fn unmap_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>) {
+        self.unmap_range_and_dealloc_frames(page_table, range_vpn);
+    }
+}
+
+impl VmAreaFrameExt for UserVmArea {
+    type FrameIter<'a> = UserVmAreaFrameIter<'a>;
+    
+    fn allocated_frames_iter<'a>(&'a self) -> Self::FrameIter<'a> {
+        UserVmAreaFrameIter{
+            inner: self.pages.keys()
+        }
+    }
+    
+    fn add_allocated_frame(&mut self, vpn: VirtPageNum, frame: FrameTracker) {
+        self.pages.insert(vpn, frame);
+    }
+    
+    fn remove_allocated_frame(&mut self, vpn: VirtPageNum) {
+        self.pages.remove(&vpn);
+    }
+}
+
+pub struct UserVmAreaFrameIter<'a> {
+    inner: Keys<'a, VirtPageNum, FrameTracker>
+}
+
+impl<'a> Iterator for UserVmAreaFrameIter<'a> {
+    type Item = &'a VirtPageNum;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(missing_docs)]
+pub enum KernelVmAreaType {
+    Text, Rodata, Data, Bss, PhysMem, MemMappedReg, KernelStack
+}
+
+/// Kernel's Virtual Memory Area
+#[allow(missing_docs)]
+pub struct KernelVmArea {
+    range_va: Range<VirtAddr>,
+    pub pages: BTreeMap<VirtPageNum, FrameTracker>,
+    pub map_perm: MapPerm,
+    pub vma_type: KernelVmAreaType,
+}
+
+#[allow(missing_docs)]
+impl KernelVmArea {
+
+    pub fn new(range_va: Range<VirtAddr>, map_perm: MapPerm, vma_type: KernelVmAreaType) -> Self {
+        let range_va = (VirtAddr(range_va.start.0)).floor().into() ..
+                                        (VirtAddr(range_va.end.0)).ceil().into();
+        Self {
+            range_va,
+            pages: BTreeMap::new(),
+            map_perm,
+            vma_type
+        }
+    }
+
+    fn map_range_to(&self, page_table: &mut PageTable, ppn: PhysPageNum, range_vpn: Range<VirtPageNum>) {
+        range_vpn
+        .enumerate()
+        .for_each(|(i, vpn)| {
+            let ppn = PhysPageNum(ppn.0 + i);
+            page_table.map(vpn, ppn, (*self.perm()).into());
+        });
+    }
+
+    pub fn map_range_highly(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>) {
+        self.map_range_to(page_table, PhysPageNum(self.start_vpn().0 & !(KERNEL_ADDR_OFFSET >> 12)), range_vpn);
+    }
+}
+
+impl VmArea for KernelVmArea {
+    fn range_va(&self) -> &Range<VirtAddr> {
+        &self.range_va
+    }
+
+    fn range_va_mut(&mut self) -> &mut Range<VirtAddr> {
+        &mut self.range_va
+    }
+
+    fn perm(&self) -> &MapPerm {
+        &self.map_perm
+    }
+
+    fn perm_mut(&mut self) -> &mut MapPerm {
+        &mut self.map_perm
+    }
+    
+    fn map_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>) {
+        match self.vma_type {
+            KernelVmAreaType::Bss |
+            KernelVmAreaType::Data |
+            KernelVmAreaType::MemMappedReg |
+            KernelVmAreaType::PhysMem |
+            KernelVmAreaType::Rodata |
+            KernelVmAreaType::Text => self.map_range_highly(page_table, range_vpn),
+            KernelVmAreaType::KernelStack => self.map_range_and_alloc_frames(page_table, range_vpn),
+        }
+    }
+    
+    fn unmap_range(&mut self, page_table: &mut PageTable, range_vpn: Range<VirtPageNum>) {
+
+        match self.vma_type {
+            KernelVmAreaType::Bss |
+            KernelVmAreaType::Data |
+            KernelVmAreaType::MemMappedReg |
+            KernelVmAreaType::PhysMem |
+            KernelVmAreaType::Rodata |
+            KernelVmAreaType::Text => {
+                range_vpn
+                .for_each(|vpn| {
+                    page_table.unmap(vpn);
+                });
+            },
+            KernelVmAreaType::KernelStack => self.unmap_range_and_dealloc_frames(page_table, range_vpn),
+        }
+        
+    }
+}
+
+impl VmAreaFrameExt for KernelVmArea {
+    type FrameIter<'a> = KernelVmAreaFrameIter<'a>;
+
+    fn allocated_frames_iter<'a>(&'a self) -> Self::FrameIter<'a> {
+        KernelVmAreaFrameIter { inner: self.pages.keys() }
+    }
+
+    fn add_allocated_frame(&mut self, vpn: VirtPageNum, frame: FrameTracker) {
+        self.pages.insert(vpn, frame);
+    }
+
+    fn remove_allocated_frame(&mut self, vpn: VirtPageNum) {
+        self.pages.remove(&vpn);
+    }
+}
+
+pub struct KernelVmAreaFrameIter<'a> {
+    inner: Keys<'a, VirtPageNum, FrameTracker>
+}
+
+impl<'a> Iterator for KernelVmAreaFrameIter<'a> {
+    type Item = &'a VirtPageNum;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}

--- a/os/src/mm/vm_space.rs
+++ b/os/src/mm/vm_space.rs
@@ -1,0 +1,370 @@
+use core::ops::{Deref, DerefMut};
+
+use crate::{board::{MEMORY_END, MMIO}, config::{KERNEL_ADDR_OFFSET, PAGE_SIZE, TRAP_CONTEXT, USER_MEMORY_SPACE, USER_STACK_SIZE}, mm::{vm_area::{KernelVmAreaType, MapPerm, UserVmArea, UserVmAreaType}, VirtAddr, VirtPageNum}, sync::UPSafeCell};
+
+use super::{page_table::PageTable, vm_area::{KernelVmArea, VmArea}, PageTableEntry};
+
+use alloc::vec::Vec;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// a memory set instance through lazy_static! managing kernel space
+    pub static ref KERNEL_SPACE: UPSafeCell<KernelVmSpace> = 
+        unsafe { UPSafeCell::new(KernelVmSpace::new()) };
+}
+
+#[allow(missing_docs)]
+pub trait VmSpace {
+    type VmAreaType: VmArea;
+    fn get_page_table(&self) -> &PageTable;
+
+    fn get_page_table_mut(&mut self) -> &mut PageTable;
+
+    fn enable(&self) {
+        unsafe { self.get_page_table().enable() };
+    }
+
+    fn token(&self) -> usize {
+        self.get_page_table().token()
+    }
+
+    fn translate(&self, vpn: VirtPageNum) -> Option<PageTableEntry> {
+        self.get_page_table().translate(vpn)
+    }
+
+    fn push(&mut self, map_area: Self::VmAreaType, data: Option<&[u8]>);
+
+    fn remove_area_with_start_vpn(&mut self, start_vpn: VirtPageNum);
+}
+
+pub struct BaseVmSpace<V: VmArea> {
+    pub page_table: PageTable,
+    areas: Vec<V>
+}
+
+impl<V: VmArea> BaseVmSpace<V> {
+    pub fn shrink_to(&mut self, start: VirtAddr, new_end: VirtAddr) -> bool {
+        if let Some(area) = self.areas
+            .iter_mut()
+            .find(|area| area.start_vpn() == start.floor())
+        {   
+            area.shrink_to( &mut self.page_table, new_end.ceil());
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn append_to(&mut self, start: VirtAddr, new_end: VirtAddr) -> bool {
+        if let Some(area) = self.areas
+            .iter_mut()
+            .find(|area| area.start_vpn() == start.floor())
+        {
+            area.append_to(&mut self.page_table, new_end.ceil());
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn recycle_data_pages(&mut self) {
+        self.areas.clear();
+    }
+}
+
+impl<V: VmArea> VmSpace for BaseVmSpace<V> {
+    type VmAreaType = V;
+
+    fn get_page_table(&self) -> &PageTable {
+        &self.page_table
+    }
+
+    fn get_page_table_mut(&mut self) -> &mut PageTable {
+        &mut self.page_table
+    }
+    
+    fn push(&mut self, mut map_area: Self::VmAreaType, data: Option<&[u8]>) {
+        map_area.map(self.get_page_table_mut());
+        if let Some(data) = data {
+            map_area.copy_data(&self.get_page_table_mut(), data);
+        }
+        self.areas.push(map_area);
+    }
+    
+    fn remove_area_with_start_vpn(&mut self, start_vpn: VirtPageNum) {
+        if let Some((idx, area)) = self
+            .areas
+            .iter_mut()
+            .enumerate()
+            .find(|(_, area)| area.start_vpn() == start_vpn)
+        {
+            area.unmap(&mut self.page_table);
+            self.areas.swap_remove(idx);
+        }
+    }
+
+}
+
+pub struct KernelVmSpace {
+    base: BaseVmSpace<KernelVmArea>
+}
+
+impl Deref for KernelVmSpace {
+    type Target = BaseVmSpace<KernelVmArea>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+impl DerefMut for KernelVmSpace {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+impl KernelVmSpace {
+
+    pub fn new() -> Self {
+        extern "C" {
+            fn stext();
+            fn etext();
+            fn srodata();
+            fn erodata();
+            fn sdata();
+            fn edata();
+            fn sbss_with_stack();
+            fn ebss();
+            fn ekernel();
+        }
+
+        let mut ret = Self {
+            base: BaseVmSpace {
+                page_table: PageTable::new(),
+                areas: Vec::new()
+            }
+        };
+        ret.push(
+            KernelVmArea::new(
+                (stext as usize).into()..(etext as usize).into(), 
+                MapPerm::X | MapPerm::R, 
+                KernelVmAreaType::Text
+            ),
+            None
+        );
+
+        ret.push(
+            KernelVmArea::new(
+                (srodata as usize).into()..(erodata as usize).into(), 
+                MapPerm::R, 
+                KernelVmAreaType::Rodata
+            ),
+            None
+        );
+
+
+        ret.push(
+            KernelVmArea::new(
+                (sdata as usize).into()..(edata as usize).into(), 
+                MapPerm::R | MapPerm::W, 
+                KernelVmAreaType::Data
+            ),
+            None
+        );
+
+        ret.push(
+            KernelVmArea::new(
+                (sbss_with_stack as usize).into()..(ebss as usize).into(), 
+                MapPerm::R | MapPerm::W, 
+                KernelVmAreaType::Bss
+            ),
+            None
+        );
+
+        ret.push(
+            KernelVmArea::new(
+                (ekernel as usize).into()..(MEMORY_END + KERNEL_ADDR_OFFSET).into(), 
+                MapPerm::R | MapPerm::W, 
+                KernelVmAreaType::PhysMem
+            ),
+            None
+        );
+
+        for pair in MMIO {
+            ret.push(
+                KernelVmArea::new(
+                    ((*pair).0 + KERNEL_ADDR_OFFSET).into()..((*pair).0 + KERNEL_ADDR_OFFSET + (*pair).1).into(),
+                    MapPerm::R | MapPerm::W,
+                    KernelVmAreaType::MemMappedReg
+                ),
+                None,
+            );
+        }
+
+        ret
+    }
+
+}
+
+#[allow(missing_docs)]
+pub struct UserVmSpace {
+    base: BaseVmSpace<UserVmArea>
+}
+
+impl Deref for UserVmSpace {
+    type Target = BaseVmSpace<UserVmArea>;
+
+    fn deref(&self) -> &Self::Target {
+        & self.base
+    }
+}
+
+impl DerefMut for UserVmSpace {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+#[allow(missing_docs)]
+impl UserVmSpace {
+    pub fn from_kernel(kernel_vm_space: &KernelVmSpace) -> Self {
+        let page_table = PageTable::new();
+        page_table.root_ppn.get_pte_array().copy_from_slice(&kernel_vm_space.page_table.root_ppn.get_pte_array()[..]);
+        Self {
+            base: BaseVmSpace {
+                page_table,
+                areas: Vec::new()
+            }
+        }
+    }
+
+    pub fn from_elf(elf_data: &[u8]) -> (Self, usize, usize) {
+        let mut ret = Self::from_kernel(&KERNEL_SPACE.exclusive_access());
+        let elf = xmas_elf::ElfFile::new(elf_data).unwrap();
+        let elf_header = elf.header;
+        let magic = elf_header.pt1.magic;
+        assert_eq!(magic, [0x7f, 0x45, 0x4c, 0x46], "invalid elf!");
+        let ph_count = elf_header.pt2.ph_count();
+        let mut max_end_vpn = VirtPageNum(0);
+        
+        for i in 0..ph_count {
+            let ph = elf.program_header(i).unwrap();
+            if ph.get_type().unwrap() == xmas_elf::program::Type::Load {
+                let start_va: VirtAddr = (ph.virtual_addr() as usize).into();
+                let end_va: VirtAddr = ((ph.virtual_addr() + ph.mem_size()) as usize).into();
+                println!("start_va: {:#x}, end_va: {:#x}", start_va.0, end_va.0);
+
+                let mut map_perm = MapPerm::U;
+                let ph_flags = ph.flags();
+                if ph_flags.is_read() {
+                    map_perm |= MapPerm::R;
+                }
+                if ph_flags.is_write() {
+                    map_perm |= MapPerm::W;
+                }
+                if ph_flags.is_execute() {
+                    map_perm |= MapPerm::X;
+                }
+                let map_area = UserVmArea::new(start_va..end_va, map_perm, UserVmAreaType::Elf);
+                max_end_vpn = map_area.end_vpn();
+                ret.push(
+                    map_area,
+                    Some(&elf.input[ph.offset() as usize..(ph.offset() + ph.file_size()) as usize]),
+                );
+            }
+        };
+        
+        // map user stack with U flags
+        let max_end_va: VirtAddr = max_end_vpn.into();
+        let mut user_stack_bottom: usize = max_end_va.into();
+        // guard page
+        user_stack_bottom += PAGE_SIZE;
+        let user_stack_top = user_stack_bottom + USER_STACK_SIZE;
+        let user_stack_top_extend = user_stack_top;
+        println!("user_stack_bottom: {:#x}, user_stack_top: {:#x}", user_stack_bottom, user_stack_top);
+        ret.push(
+            UserVmArea::new(
+                user_stack_bottom.into()..user_stack_top_extend.into(),
+                MapPerm::R | MapPerm::W | MapPerm::U,
+                UserVmAreaType::Elf
+            ),
+            None,
+        );
+        // used in sbrk
+        ret.push(
+            UserVmArea::new(
+                user_stack_top.into()..user_stack_top.into(),
+                MapPerm::R | MapPerm::W | MapPerm::U,
+                UserVmAreaType::Elf,
+            ),
+            None,
+        );
+        println!("trap_context: {:#x}", TRAP_CONTEXT);
+        // map TrapContext
+        ret.push(
+            UserVmArea::new(
+                TRAP_CONTEXT.into()..(USER_MEMORY_SPACE.1).into(),
+                MapPerm::R | MapPerm::W,
+                UserVmAreaType::Elf
+            ),
+            None,
+        );
+        (
+            ret,
+            user_stack_top,
+            elf.header.pt2.entry_point() as usize,
+        )
+    }
+
+    pub fn from_existed(user_space: &UserVmSpace) -> Self {
+        let mut ret = Self::from_kernel(&KERNEL_SPACE.exclusive_access());
+        for area in user_space.areas.iter() {
+            let new_area = area.clone();
+            ret.push(new_area, None);
+            for vpn in area.range_vpn() {
+                let src_ppn = user_space.translate(vpn).unwrap().ppn();
+                let dst_ppn = ret.translate(vpn).unwrap().ppn();
+                dst_ppn
+                    .get_bytes_array()
+                    .copy_from_slice(src_ppn.get_bytes_array());
+            }
+        }
+        ret
+    }
+
+}
+
+
+#[allow(missing_docs, unused)]
+pub fn remap_test() {
+    extern "C" {
+        fn stext();
+        fn etext();
+        fn srodata();
+        fn erodata();
+        fn sdata();
+        fn edata();
+    }
+
+    let mut kernel_space = KERNEL_SPACE.exclusive_access();
+    let mid_text: VirtAddr = (stext as usize + ((etext as usize - stext as usize) >> 1)).into();
+    let mid_rodata: VirtAddr = (srodata as usize + ((erodata as usize - srodata as usize) >> 1)).into();
+    let mid_data: VirtAddr = (sdata as usize + ((edata as usize - sdata as usize) >> 1)).into();
+    assert!(!kernel_space
+        .page_table
+        .translate(mid_text.floor())
+        .unwrap()
+        .writable(),);
+    assert!(!kernel_space
+        .page_table
+        .translate(mid_rodata.floor())
+        .unwrap()
+        .writable(),);
+    assert!(!kernel_space
+        .page_table
+        .translate(mid_data.floor())
+        .unwrap()
+        .executable(),);
+    println!("remap_test passed!");
+}
+

--- a/os/src/syscall/process.rs
+++ b/os/src/syscall/process.rs
@@ -1,5 +1,5 @@
 use crate::fs::{open_file, OpenFlags};
-use crate::mm::{translated_refmut, translated_str};
+use crate::mm::{translated_refmut, translated_str, VmSpace};
 use crate::task::{
     add_task, current_task, current_user_token, exit_current_and_run_next,
     suspend_current_and_run_next,
@@ -81,7 +81,7 @@ pub fn sys_waitpid(pid: isize, exit_code_ptr: *mut i32) -> isize {
         // ++++ temporarily access child PCB exclusively
         let exit_code = child.inner_exclusive_access().exit_code;
         // ++++ release child PCB
-        *translated_refmut(inner.memory_set.token(), exit_code_ptr) = exit_code;
+        *translated_refmut(inner.vm_space.token(), exit_code_ptr) = exit_code;
         found_pid as isize
     } else {
         -2

--- a/os/src/task/mod.rs
+++ b/os/src/task/mod.rs
@@ -103,7 +103,7 @@ pub fn exit_current_and_run_next(exit_code: i32) {
 
     inner.children.clear();
     // deallocate user space
-    inner.memory_set.recycle_data_pages();
+    inner.vm_space.recycle_data_pages();
     drop(inner);
     // **** release current PCB
     // drop task manually to maintain rc correctly

--- a/os/src/trap/context.rs
+++ b/os/src/trap/context.rs
@@ -11,12 +11,8 @@ pub struct TrapContext {
     pub sstatus: Sstatus,
     /// CSR sepc
     pub sepc: usize,
-    /// Addr of Page Table
-    pub kernel_satp: usize,
     /// kernel stack
     pub kernel_sp: usize,
-    /// Addr of trap_handler function
-    pub trap_handler: usize,
 }
 
 impl TrapContext {
@@ -28,9 +24,7 @@ impl TrapContext {
     pub fn app_init_context(
         entry: usize,
         sp: usize,
-        kernel_satp: usize,
         kernel_sp: usize,
-        trap_handler: usize,
     ) -> Self {
         let mut sstatus = sstatus::read();
         // set CPU privilege to User after trapping back
@@ -39,9 +33,7 @@ impl TrapContext {
             x: [0; 32],
             sstatus,
             sepc: entry,
-            kernel_satp,
             kernel_sp,
-            trap_handler,
         };
         cx.set_sp(sp);
         cx

--- a/os/src/trap/trap.S
+++ b/os/src/trap/trap.S
@@ -5,7 +5,7 @@
 .macro LOAD_GP n
     ld x\n, \n*8(sp)
 .endm
-    .section .text.trampoline
+    .section .text
     .globl __alltraps
     .globl __restore
     .align 2
@@ -31,23 +31,16 @@ __alltraps:
     # read user stack from sscratch and save it in TrapContext
     csrr t2, sscratch
     sd t2, 2*8(sp)
-    # load kernel_satp into t0
-    ld t0, 34*8(sp)
-    # load trap_handler into t1
-    ld t1, 36*8(sp)
     # move to kernel_sp
-    ld sp, 35*8(sp)
-    # switch to kernel space
-    csrw satp, t0
-    sfence.vma
+    ld sp, 34*8(sp)
     # jump to trap_handler
-    jr t1
+    call trap_handler
 
 __restore:
     # a0: *TrapContext in user space(Constant); a1: user space token
-    # switch to user space
-    csrw satp, a1
-    sfence.vma
+    csrr t0, satp
+    bne t0, a1, __switch_user
+__restore_1:
     csrw sscratch, a0
     mv sp, a0
     # now sp points to TrapContext in user space, start restoring based on it
@@ -67,3 +60,9 @@ __restore:
     # back to user stack
     ld sp, 2*8(sp)
     sret
+
+__switch_user:
+    # switch to user space
+    csrw satp, a1
+    sfence.vma
+    j __restore_1


### PR DESCRIPTION
### Improvement:
1. get the user and kernel to share the page table
2. eliminate the trampoline page
3. separate the management logic of the kernel and user address spaces
### Problem:
1. the kernel stack must be allocated before the user page table is created
2. ...